### PR TITLE
Adding a copy function 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ If no variables are set, applying this role will result in a configuration equiv
 | `httpd_LogLevel_ssl`            | warn                                       |                                                                                       |
 | `httpd_LogLevel`                | warn                                       |                                                                                       |
 | `httpd_SSLCACertificateFile`    | -                                          |                                                                                       |
-| `httpd_SSLCertificateChainFile` | -                                          |                                                                                       |
+| `httpd_SSLCertificateChainFile` | -                                          |                                                                                                                                                                           |
+| `httpd_SSLCertificateKeyFile_Source`            | -                                       | The location of the .crt and .key files |
+| `httpd_SSLCertificateKeyFile_Dest`            | /etc/pki/tls/certs/                                       | The destination directory where certification files will be pasted. |
 | `httpd_SSLCertificateFile`      | /etc/pki/tls/certs/localhost.crt           |                                                                                       |
 | `httpd_SSLCertificateKeyFile`   | /etc/pki/tls/private/localhost.key         |                                                                                       |
 | `httpd_SSLCipherSuite`          | See [default variables](defaults/main.yml) |                                                                                       |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ httpd_ErrorLog_ssl: logs/ssl_error_log
 httpd_AccessLog_ssl: logs/ssl_access_log
 httpd_LogLevel_ssl: warn
 
+httpd_SSLCertificateKeyFile_Dest: /etc/pki/tls/certs/
 httpd_SSLCertificateFile:  /etc/pki/tls/certs/localhost.crt
 httpd_SSLCertificateKeyFile: /etc/pki/tls/private/localhost.key
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,12 @@
     - "{{ ansible_os_family }}.yml"
   tags: httpd
 
+- name: Copy Certificate Files
+  copy:
+    src: "{{ item }}"
+    dest: "{{ httpd_SSLCertificateKeyFile_Dest }}"
+  with_items: "{{ httpd_SSLCertificateKeyFile_Source }}"
+
 - name: Ensure Apache is installed
   package:
     name: "{{ item }}"


### PR DESCRIPTION
Adding a copy function  to paste certification files into the correct folder on the vm. This can be done using other roles but I found that this is the most easy solution.